### PR TITLE
Run excerpts through marked

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 
 var debug = require('debug')('metalsmith-excerpts');
 var extname = require('path').extname;
+var marked = require('marked');
 
 /**
  * Expose `plugin`.
@@ -25,9 +26,11 @@ function plugin(options){
       var str = data.contents.toString();
       var i = str.indexOf('\n\n');
       debug('storing excerpt: %s', file);
-      data.excerpt = ~i
+      var rawExcerpt = ~i
         ? str.substring(0, i)
         : '';
+
+      data.excerpt = marked(rawExcerpt);
     });
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "marked": "~0.3.1",
     "debug": "~0.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Ran into this issue when using excerpts. I added marked as a dependency to keep it in line with the metalsmith-markdown plugin.

Hope it's useful!
