### PR TITLE
Fix reference-style links in first paragraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/fixtures/*/build

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 
 var debug = require('debug')('metalsmith-excerpts');
 var extname = require('path').extname;
-var marked = require('marked');
 var cheerio = require('cheerio');
 
 /**
@@ -22,12 +21,10 @@ function plugin(options){
     setImmediate(done);
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
-      if (!markdown(file)) return;
+      if (!html(file)) return;
       var data = files[file];
 
-      var html = marked(data.contents.toString());
-
-      var $ = cheerio.load(html, {
+      var $ = cheerio.load(data.contents.toString(), {
         normalizeWhitespace: true
       });
       var firstParagraph = $('p').first();
@@ -45,6 +42,6 @@ function plugin(options){
  * @return {Boolean}
  */
 
-function markdown(file){
-  return /\.md|\.markdown/.test(extname(file));
+function html(file){
+  return /\.html|\.htm/.test(extname(file));
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "main": "lib/index.js",
   "dependencies": {
     "cheerio": "^0.15.0",
-    "debug": "~0.7.4",
-    "marked": "~0.3.1"
+    "debug": "~0.7.4"
   },
   "devDependencies": {
-    "mocha": "1.x",
     "metalsmith": "0.x",
+    "metalsmith-markdown": "^0.2.1",
+    "mocha": "1.x",
     "swig": "~1.3.2"
   }
 }

--- a/test/fixtures/basic/build/index.md
+++ b/test/fixtures/basic/build/index.md
@@ -1,4 +1,0 @@
-
-excerpt
-
-more content

--- a/test/fixtures/indented-paragraph/build/index.md
+++ b/test/fixtures/indented-paragraph/build/index.md
@@ -1,5 +1,0 @@
-
-    This is code.
-
-This is the excerpt.
-

--- a/test/fixtures/one-paragraph/build/index.md
+++ b/test/fixtures/one-paragraph/build/index.md
@@ -1,2 +1,0 @@
-
-excerpt

--- a/test/fixtures/reference-links/build/index.md
+++ b/test/fixtures/reference-links/build/index.md
@@ -1,5 +1,0 @@
-
-This is [a link][a].
-
-[a]: http://example.com
-

--- a/test/fixtures/whitespace/build/index.md
+++ b/test/fixtures/whitespace/build/index.md
@@ -1,8 +1,0 @@
-
-
-
-
-
-excerpt
-
-more content

--- a/test/index.js
+++ b/test/index.js
@@ -1,55 +1,61 @@
 
 var assert = require('assert');
 var excerpt = require('..');
+var markdown = require('metalsmith-markdown');
 var Metalsmith = require('metalsmith');
 
 describe('metalsmith-excerpts', function(){
   it('should convert excerpt files', function(done){
     Metalsmith('test/fixtures/basic')
+      .use(markdown())
       .use(excerpt())
       .build(function(err, files){
         if (err) return done(err);
-        assert.equal('<p>excerpt</p>', files['index.md'].excerpt);
+        assert.equal('<p>excerpt</p>', files['index.html'].excerpt);
         done();
       });
   });
 
   it('should convert excerpt files that have leading whitespace', function(done){
     Metalsmith('test/fixtures/whitespace')
+      .use(markdown())
       .use(excerpt())
       .build(function(err, files){
         if (err) return done(err);
-        assert.equal('<p>excerpt</p>', files['index.md'].excerpt);
+        assert.equal('<p>excerpt</p>', files['index.html'].excerpt);
         done();
       });
   });
 
   it('should convert excerpt files that only have one paragraph', function(done){
     Metalsmith('test/fixtures/one-paragraph')
+      .use(markdown())
       .use(excerpt())
       .build(function(err, files){
         if (err) return done(err);
-        assert.equal('<p>excerpt</p>', files['index.md'].excerpt);
+        assert.equal('<p>excerpt</p>', files['index.html'].excerpt);
         done();
       });
   });
 
   it('should convert excerpt files with reference-style links', function(done) {
     Metalsmith('test/fixtures/reference-links')
+      .use(markdown())
       .use(excerpt())
       .build(function(err, files) {
         if (err) return done(err);
-        assert.equal('<p>This is <a href="http://example.com">a link</a>.</p>', files['index.md'].excerpt);
+        assert.equal('<p>This is <a href="http://example.com">a link</a>.</p>', files['index.html'].excerpt);
         done();
       });
   });
 
   it('should skip excerpts with leading whitespace', function(done) {
     Metalsmith('test/fixtures/indented-paragraph')
+      .use(markdown())
       .use(excerpt())
       .build(function(err, files) {
         if (err) return done(err);
-        assert.equal('<p>This is the excerpt.</p>', files['index.md'].excerpt);
+        assert.equal('<p>This is the excerpt.</p>', files['index.html'].excerpt);
         done();
       });
   });


### PR DESCRIPTION
This fixes issue #5.

Instead of finding the first paragraph from the Markdown source, convert it to HTML and then find the first `<p>` tag using cheerio.  Two new tests are also included to ensure reference-style links are converted to anchor tags correctly and to ensure that the excerpt is the first Markdown paragraph, not a code block.

Also, whitespace is now trimmed from excerpts before adding them to a file.
