### PR TITLE
Multiple formats

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,9 @@ var excerpts = require('metalsmith-excerpts');
 metalsmith.use(excerpts());
 ```
 
+If you pass a `multipleFormats: true` option to the plugin, it will put store
+an excerpt object like `{ html: '...', text: '...' }`;
+
 ## License
 
 MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ const html = file => /\.html?/.test(extname(file));
  *
  * @return {Function}
  */
-const plugin = () => (files, metalsmith, done) => {
+const plugin = options => (files, metalsmith, done) => {
+  options = options || {};
   setImmediate(done);
   Object.keys(files).forEach(file => {
     debug('checking file: %s', file);
@@ -36,7 +37,14 @@ const plugin = () => (files, metalsmith, done) => {
       p = p.next();
     }
 
-    data.excerpt = $.html(p).trim();
+    if (options.multipleFormats) {
+      data.excerpt = {
+        html: $.html(p).trim(),
+        text: $.text(p).trim()
+      };
+    } else {
+      data.excerpt = $.html(p).trim();
+    }
   });
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,21 @@ test('should skip excerpts with leading whitespace', assert => {
     });
 });
 
+test('should convert excerpts with multiple formats', assert => {
+  metalsmith('test/fixtures/reference-links')
+    .use(markdown())
+    .use(excerpt({multipleFormats: true}))
+    .build((err, files) => {
+      if (err) {
+        return err;
+      }
+
+      assert.equal('<p>This is <a href="http://example.com">a link</a>.</p>', files['index.html'].excerpt.html);
+      assert.equal('This is a link.', files['index.html'].excerpt.text);
+      assert.end();
+    });
+});
+
 test('should skip excerpts with images', assert => {
   metalsmith('test/fixtures/first-paragraph-image')
     .use(markdown())


### PR DESCRIPTION
Allow outputting of the excerpt in both html and text formats by passing a `multipleFormats: true` option to the plugin. Excerpt will look like `{ html: '...', text: '...' }`